### PR TITLE
Fix NVM installation and npm install shell commands.

### DIFF
--- a/resources/tools/nvm.json
+++ b/resources/tools/nvm.json
@@ -15,12 +15,10 @@
                     "cmd": [
                         "{ echo 'export NVM_DIR=\"/opt/nvm\"'; echo '[ -s \"$NVM_DIR/nvm.sh\" ]",
                         "\\. \"$NVM_DIR/nvm.sh\"  # This loads nvm'; echo '[ -s \"$NVM_DIR/bash_completion\" ]",
-                        "\\. \"$NVM_DIR/bash_completion\"  # This loads nvm bash_completion'; } >> /home/${MY_USER}/${BASH_PROFILE}",
+                        "\\. \"$NVM_DIR/bash_completion\"  # This loads nvm bash_completion'; } >> /home/${MY_USER}/.profile",
                         "chown -R ${MY_USER}:${MY_GROUP} /opt/nvm",
-                        "su -c '. /opt/nvm/nvm.sh; nvm install node' ${MY_USER}",
-                        "su -c '. /opt/nvm/nvm.sh; nvm install --lts' ${MY_USER}",
-                        "su -c '. /opt/nvm/nvm.sh; nvm use node' ${MY_USER}",
-                        "ln -sf /opt/nvm/nvm.sh /usr/local/bin/nvm"
+                        "su -l -c 'nvm install --lts' ${MY_USER}",
+                        "su -l -c 'nvm use --lts' ${MY_USER}"
                     ]
                 }
             },

--- a/src/Command/NpmInstallCommand.php
+++ b/src/Command/NpmInstallCommand.php
@@ -27,6 +27,6 @@ final class NpmInstallCommand implements CommandInterface
 
     public function __toString(): string
     {
-        return sprintf('npm install %s %s', $this->requirement, implode(' ', $this->flags));
+        return sprintf("su -l -c 'npm install %s %s'" . ' ${MY_USER}', $this->requirement, implode(' ', $this->flags));
     }
 }


### PR DESCRIPTION
Fixes #13 

Fixes the issue with `node` and `npm` commands not being available after installing node with NVM.
We need to add the nvm script to ~/.profile so it can be autoloaded when using an su login-shell.
Ex: `su -l -c 'npm install -g yarn'`

I also adjusted the shell command so it only installs the latest LTS version instead of installing both LTS and latest version. If someone needs a different version, they can just run nvm to install and use their specifically needed version.