### PR TITLE
Dockerfile: fix PATH variables being substituted instead of being output literally.

### DIFF
--- a/Dockerfiles/work/Dockerfile
+++ b/Dockerfiles/work/Dockerfile
@@ -111,8 +111,7 @@ RUN set -eux \
 ###
 RUN \
     { \
-        echo "PATH=\"${PATH}:${HOME}/.composer/vendor/bin\""; \
-        echo "PATH=\"${PATH}:/usr/local/bin:/usr/local/sbin\""; \
+        echo 'PATH="${PATH}:${HOME}/.composer/vendor/bin'; \
         echo "export PATH"; \
         echo ". /etc/bash-devilbox"; \
         echo "if [ -d /etc/bashrc-devilbox.d/ ]; then"; \


### PR DESCRIPTION
Configure Bash step, PATH and HOME variables are being substituted with Dockerfile variables. These variables should be output literally so they are used by bash variables.